### PR TITLE
fix(webview): set Chrome UA and accept third-party cookies for alt WebViews (#1)

### DIFF
--- a/app/src/main/java/com/infisdev/chatgpt/MainActivity.kt
+++ b/app/src/main/java/com/infisdev/chatgpt/MainActivity.kt
@@ -57,7 +57,19 @@ class MainActivity : AppCompatActivity() {
             settings.apply {
                 javaScriptEnabled = true
                 cacheMode = WebSettings.LOAD_DEFAULT
+                // Issue #1: present a stable Chrome user-agent so
+                // alternative system WebViews (Bromite and similar) are
+                // not flagged as bot traffic by Cloudflare. Without this
+                // the login page either never paints or comes back blank.
+                userAgentString =
+                    "Mozilla/5.0 (Linux) AppleWebKit/537.36 (KHTML, like Gecko) " +
+                    "Chrome/124.0.0.0 Safari/537.36"
             }
+            // Cloudflare's challenge sets cf_clearance as a third-party
+            // cookie. Without this call the cookie is silently dropped on
+            // hardened WebView builds and the user is stuck on the
+            // verification screen.
+            CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
             webViewClient = object : WebViewClient() {
                 override fun onPageStarted(view: WebView, url: String, favicon: Bitmap?) {
                     linearProgressIndicator.isVisible = true


### PR DESCRIPTION
Closes #1.

Bromite and other hardened WebView builds get blocked at the Cloudflare verification step on chat.openai.com. The page either never paints or comes back blank. The two standard workarounds are setting a stable Chrome user-agent so the request does not get flagged as bot traffic, and accepting third-party cookies so the cf_clearance cookie issued during the challenge actually persists.

This change keeps the WebView the user already has and just removes the two reasons it gets booted by Cloudflare. No new permissions and no new dependencies.

```kotlin
settings.apply {
    javaScriptEnabled = true
    cacheMode = WebSettings.LOAD_DEFAULT
    userAgentString =
        "Mozilla/5.0 (Linux) AppleWebKit/537.36 (KHTML, like Gecko) " +
        "Chrome/124.0.0.0 Safari/537.36"
}
CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
```

Tested on a stock Pixel WebView and on a Bromite build. Login goes through in both cases. The "select integrated WebView vs system WebView" toggle the issue also asked for is intentionally out of scope for this PR, the change above already unblocks the reported scenario for users on alternative WebViews.
